### PR TITLE
Remove language param when working with multiTreeMethod

### DIFF
--- a/Classes/LanguageDetection.php
+++ b/Classes/LanguageDetection.php
@@ -339,7 +339,7 @@ class LanguageDetection extends AbstractPlugin {
 			'addQueryString.' => array(
 				'exclude' => 'id'
 			),
-			'additionalParams' => '&' . $this->conf['languageGPVar'] . '=' . $preferredLanguageOrPageUid
+			'additionalParams' => $this->conf['useOneTreeMethod'] ? '&' . $this->conf['languageGPVar'] . '=' . $preferredLanguageOrPageUid : ''
 		));
 
 		// Prefer the base URL if available


### PR DESCRIPTION
If multiTree is used, we do not need a language param in the url the user is redirected to
